### PR TITLE
python-clanglite should depend on libclanglite at runtime

### DIFF
--- a/bin/conda/python-clanglite/meta.yaml
+++ b/bin/conda/python-clanglite/meta.yaml
@@ -50,7 +50,8 @@ requirements:
     - libclanglite 4.0.1
   run:
     - python
+    - libclanglite 4.0.1
 
-test:   
+test:
   imports:
     - clanglite


### PR DESCRIPTION
Otherwise the recipe test fails with an error like

ImportError: dlopen(/Users/aaronmeurer/anaconda3/conda-bld/python-clanglite_1519593420214/_t_env/lib/python2.7/site-packages/clanglite/__clanglite.so, 2): Library not loaded: @rpath/libclanglite.dylib
  Referenced from: /Users/aaronmeurer/anaconda3/conda-bld/python-clanglite_1519593420214/_t_env/lib/python2.7/site-packages/clanglite/__clanglite.so
  Reason: image not found
TESTS FAILED: python-clanglite-4.0.1-py27_0.tar.bz2